### PR TITLE
Remove tests that rely on assert not being optimized out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,2 @@
 language: haskell
 
-script:
-  - cabal configure --enable-tests --disable-optimization && cabal build && cabal test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ configure:
 	cabal configure
 
 configureTest:
-	cabal configure --enable-tests --disable-optimization
+	cabal configure --enable-tests 
 
 lint:
 	hlint .

--- a/src/BACnet/Tag/Core.hs
+++ b/src/BACnet/Tag/Core.hs
@@ -59,11 +59,9 @@ isExtendedLength :: Word8 -> Bool
 isExtendedLength = (== 0x05) . lvt
 
 
--- | Returns the tag number valud encoded into an initial octet.
+-- | Returns the tag number value encoded into an initial octet.
 --   As one would expect it can't return the actual tag number in the
 --   case of extended tag numbers since it is only given the initial octet
 --   as input.
 tagNumber :: Word8 -> Word8
-tagNumber b | isCS b = tNum
-            | otherwise = assert (tNum < 13) tNum
-  where tNum = (0x0F .&.) $ shiftR b 4
+tagNumber = (0x0F .&.) . flip shiftR 4

--- a/test/BACnet/Tag/CoreSpec.hs
+++ b/test/BACnet/Tag/CoreSpec.hs
@@ -51,11 +51,7 @@ spec = do
     it "returns True if lvt == 5, else False" $
       property (\b -> isExtendedLength b `shouldBe` (lvt b == 5))
 
-  describe "tagNumber" $ do
-    it "throws an AssertionException if tagNumber > 12 and isAP" $ do
-      evaluate (tagNumber 0xD5) `shouldThrow` anyAssertionFailed
-      evaluate (tagNumber 0xE4) `shouldThrow` anyAssertionFailed
-      evaluate (tagNumber 0xF0) `shouldThrow` anyAssertionFailed
-
-    it "returns 15 if tagNumber is 15 and isCS" $
-      tagNumber 0xF8 `shouldBe` 15
+  describe "tagNumber" $
+    it "returns the 4 most significants bits shifted right 4 (without sign extension)" $
+      property $ forAll (choose (0,15))
+      (\n -> tagNumber (shiftL n 4) `shouldBe` n)


### PR DESCRIPTION
I had a couple of tests that only passed if I disabled optimizations.
After looking at the tests, I thought the code that made them pass
was doing unnecessary checks. So I removed the checks and rewrote
the tests. This then allowed me to modify the Makefile and
.travis.yml file.
